### PR TITLE
Clean duplicated messages

### DIFF
--- a/Sulakore/Habbo/Messages/Incoming.cs
+++ b/Sulakore/Habbo/Messages/Incoming.cs
@@ -26,7 +26,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage BonusRareInfo { get; set; }
         public HMessage BotError { get; set; }
         public HMessage BotSettings { get; set; }
-        public HMessage BubbleAlert { get; set; }
         public HMessage BuildersClubExpired { get; set; }
         public HMessage BuildersClubFurniCount { get; set; }
         public HMessage BuildersClubSubscriptionStatus { get; set; }

--- a/Sulakore/Habbo/Messages/Incoming.cs
+++ b/Sulakore/Habbo/Messages/Incoming.cs
@@ -167,7 +167,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage HideDoorbell { get; set; }
         public HMessage HotelClosedAndOpens { get; set; }
         public HMessage HotelClosesAndWillOpenAt { get; set; }
-        public HMessage HotelView { get; set; }
         public HMessage HotelViewBadgeButtonConfig { get; set; }
         public HMessage HotelViewCatalogPageExpiring { get; set; }
         public HMessage HotelViewCommunityGoal { get; set; }

--- a/Sulakore/Habbo/Messages/Incoming.cs
+++ b/Sulakore/Habbo/Messages/Incoming.cs
@@ -263,7 +263,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage NoobnessLevel { get; set; }
         public HMessage NotEnoughPointsType { get; set; }
         public HMessage NotificationDialog { get; set; }
-        public HMessage NuxAlert { get; set; }
         public HMessage Objects { get; set; }
         public HMessage OfferRewardDelivered { get; set; }
         public HMessage OldPublicRooms { get; set; }

--- a/Sulakore/Habbo/Messages/Outgoing.cs
+++ b/Sulakore/Habbo/Messages/Outgoing.cs
@@ -357,7 +357,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage UpdateGuildSettings { get; set; }
         public HMessage UseFurniture { get; set; }
         public HMessage UseWallItem { get; set; }
-        public HMessage UserActivity { get; set; }
         public HMessage UserNux { get; set; }
         public HMessage UserSaveLook { get; set; }
         public HMessage Username { get; set; }

--- a/Sulakore/Habbo/Messages/Outgoing.cs
+++ b/Sulakore/Habbo/Messages/Outgoing.cs
@@ -357,7 +357,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage UpdateGuildSettings { get; set; }
         public HMessage UseFurniture { get; set; }
         public HMessage UseWallItem { get; set; }
-        public HMessage UserNux { get; set; }
         public HMessage UserSaveLook { get; set; }
         public HMessage Username { get; set; }
         public HMessage VersionCheck { get; set; }

--- a/Sulakore/Habbo/Messages/Outgoing.cs
+++ b/Sulakore/Habbo/Messages/Outgoing.cs
@@ -259,7 +259,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage RequestOwnItems { get; set; }
         public HMessage RequestPetBreeds { get; set; }
         public HMessage RequestPetInfo { get; set; }
-        public HMessage RequestPetTrainingPanel { get; set; }
         public HMessage RequestPopularRooms { get; set; }
         public HMessage RequestPromotedRooms { get; set; }
         public HMessage RequestPromotionRooms { get; set; }

--- a/Sulakore/Habbo/Messages/Outgoing.cs
+++ b/Sulakore/Habbo/Messages/Outgoing.cs
@@ -274,7 +274,6 @@ namespace Sulakore.Habbo.Messages
         public HMessage RequestRoomWordFilter { get; set; }
         public HMessage RequestSellItem { get; set; }
         public HMessage RequestTags { get; set; }
-        public HMessage RequestTalenTrack { get; set; }
         public HMessage RequestUserClub { get; set; }
         public HMessage RequestUserCredits { get; set; }
         public HMessage RequestUserTags { get; set; }

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -623,7 +623,6 @@ NewsWidgets = a1c4c9977d44a528dfba773ede371eee
 NoobnessLevel = 14b70bf11ec5f95aecde1529dc94c3ff
 NotEnoughPointsType = 0e2d9cd3d02bd5a56b28576bdbea8a7a
 NotificationDialog = 3ed1b2efef33a502709fdf49436f3e37
-NuxAlert = 6addca9ea5b62e65f56bb71880560eed
 Objects = f25a48ce9e67ac3615242e529f2ce5c1
 OfferRewardDelivered = b41ed62d27b6d7ce0ac30f4ffeb2f558
 OldPublicRooms = c383010b803a498ed4245b3c6518504f

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -269,7 +269,6 @@ RequestRoomSettings = 36f4574becfaee1338e1858bc0929ccb
 RequestRoomWordFilter = fa7e77d2ce15cafa3aecab57ef29566b
 RequestSellItem = 270b6bae9c93adc739c4c05ffac004f8
 RequestTags = b54bf2337423b181f57260cac478f811
-RequestTalenTrack = 9116197531d02ea41417e1015675de5e
 RequestUserClub = 021159e5d374726de0a9d5e0e77a2e47
 RequestUserCredits = 1b8ddfa328525f832da018d48301f871
 RequestUserTags = 0545a17d8a60f30050f9854856753a1b

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -352,7 +352,6 @@ UpdateGuildIdentity = 8114febbf6366ec066e989a771b78dca
 UpdateGuildSettings = -1
 UseFurniture = f8be588374f0fea6947568167f51058c
 UseWallItem = 1d024aa330734988295359742bae82d8
-UserActivity = ba6e5ec5767486804f64557233e71a03
 UserNux = 66b400aa993cfcaea7999b9e2a85f6df
 UserSaveLook = 1f03ea2553d1f3a013c2d9aa30afaa8a
 Username = 1d79f11326909f6e09ffd3e99eeeee77

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -527,7 +527,6 @@ HelperRequestDisabled = 0670bf653bacbf3ccdcaa3126122826f
 HideDoorbell = 124845697f93a5fb93e0da364ba4864d
 HotelClosedAndOpens = 59ab177c7a63ef92c3431f30044761d9
 HotelClosesAndWillOpenAt = 65e0f21beee9804b90a63bf110d8e92b
-HotelView = c0e3d744c75203dd4b24c54aba52203c
 HotelViewBadgeButtonConfig = 723ad2f6f378f4cf76bcbbfcdf6b2573
 HotelViewCatalogPageExpiring = -1
 HotelViewCommunityGoal = 1de37f1619f35288817102c529b82392

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -385,7 +385,6 @@ AvatarEffects = b5b15b2834623a7a4d8e7e425b0cf018
 BonusRareInfo = 781d784034e0120cfadf790b8925a826
 BotError = 4efe0ac4e8d8c1bce68269ed531d77e3
 BotSettings = 0177403e4aa2bf477d788bd2dc3790bc
-BubbleAlert = a13e4ac7271914da0d1b0e2b50cecbda
 BuildersClubExpired = 01d1ee9a21596d5e8d64808d92e3db3c
 BuildersClubFurniCount = b466e36548f325313cf42d82e2fec5e8
 BuildersClubSubscriptionStatus = de28e40154b07bc9522c41f0a1ee30cd

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -352,7 +352,6 @@ UpdateGuildIdentity = 8114febbf6366ec066e989a771b78dca
 UpdateGuildSettings = -1
 UseFurniture = f8be588374f0fea6947568167f51058c
 UseWallItem = 1d024aa330734988295359742bae82d8
-UserNux = 66b400aa993cfcaea7999b9e2a85f6df
 UserSaveLook = 1f03ea2553d1f3a013c2d9aa30afaa8a
 Username = 1d79f11326909f6e09ffd3e99eeeee77
 VersionCheck = 24f7f5ded037cc98bd9fc6d263b8aae3

--- a/Sulakore/Hashes.ini
+++ b/Sulakore/Hashes.ini
@@ -254,7 +254,6 @@ RequestOwnGuilds = 653c1554180de88aa24bb2d9a1228310
 RequestOwnItems = 49a49a5abbc07979c953a329f00d7e86
 RequestPetBreeds = 0c491d70133d641be13a672dff2de498
 RequestPetInfo = d876d416ac252283ece1792cb5acf5e2
-RequestPetTrainingPanel = cf55be7d1162492ea7dea8a0639a2b42
 RequestPopularRooms = 4bf2f049e31043f8695d9d3ca62dce52
 RequestPromotedRooms = 49dd2c7bfbdf78b5fc453a05e60643b8
 RequestPromotionRooms = feb84f7e1f131b6a85a963eeb7b9b400


### PR DESCRIPTION
Duplication was created when adding a new message for an already existing one. Because of the not directly obvious correlation of the names, it's easy to oversee that the new message already exists under the old given name, in which case it would be renamed. All the hashes associated with the messages to be deleted are outdated which further indicates that their message is a duplicate.