### PR TITLE
Use ISO-8859-1 for converting packet between bytes and string

### DIFF
--- a/Sulakore/Network/Protocol/HPacket.cs
+++ b/Sulakore/Network/Protocol/HPacket.cs
@@ -341,7 +341,7 @@ namespace Sulakore.Network.Protocol
         }
         protected virtual string AsString()
         {
-            string result = Encoding.Default.GetString(ToBytes());
+            string result = Encoding.Latin1.GetString(ToBytes());
             for (int i = 0; i <= 13; i++)
             {
                 result = result.Replace(((char)i).ToString(),
@@ -370,7 +370,7 @@ namespace Sulakore.Network.Protocol
                     signature = signature.Replace("[" + i + "]",
                         ((char)i).ToString());
                 }
-                return Encoding.Default.GetBytes(signature);
+                return Encoding.Latin1.GetBytes(signature);
             }
             else
             {


### PR DESCRIPTION
Just like when Tanji used .NET Framework.

Latin1 encoding can represent all bytes unambigiously.
UTF-8 loses data by using the replacement character for byte sequences that are invalid UTF-8 (https://en.wikipedia.org/wiki/UTF-8#Invalid_sequences_and_error_handling).
Side effect of this commit: wrong display of "UTF-8 byte sequences that differ from Latin1" in packets because, being in the packet, the string's bytes are displayed as Latin1 again.