### PR TITLE
Refactoring primitives & minor spanification

### DIFF
--- a/Sulakore/Cryptography/HKeyExchange.cs
+++ b/Sulakore/Cryptography/HKeyExchange.cs
@@ -3,215 +3,204 @@ using System.Numerics;
 using System.Globalization;
 using System.Security.Cryptography;
 
-namespace Sulakore.Cryptography
+namespace Sulakore.Cryptography;
+
+public class HKeyExchange : IDisposable
 {
-    public class HKeyExchange : IDisposable
+    private const int BLOCK_SIZE = 256;
+
+    public RSA RSA { get; }
+    public BigInteger Modulus { get; }
+    public BigInteger Exponent { get; }
+    public BigInteger PrivateExponent { get; }
+
+    public BigInteger DHPublic { get; private set; }
+    public BigInteger DHPrivate { get; private set; }
+
+    public BigInteger DHPrime { get; private set; }
+    public BigInteger DHGenerator { get; private set; }
+
+    public bool CanDecrypt => PrivateExponent != BigInteger.Zero;
+    public PKCSPadding Padding { get; set; } = PKCSPadding.MaxByte;
+
+    public HKeyExchange(int rsaKeySize)
     {
-        private const int BLOCK_SIZE = 256;
-        private readonly Random _numberGenerator = new Random();
+        RSA = RSA.Create(rsaKeySize);
+        RSAParameters keys = RSA.ExportParameters(true);
 
-        public RSA RSA { get; }
-        public BigInteger Modulus { get; }
-        public BigInteger Exponent { get; }
-        public BigInteger PrivateExponent { get; }
+        Modulus = new BigInteger(keys.Modulus, true, true);
+        Exponent = new BigInteger(keys.Exponent, true, true);
+        PrivateExponent = new BigInteger(keys.D, true, true);
 
-        public BigInteger DHPublic { get; private set; }
-        public BigInteger DHPrivate { get; private set; }
+        GenerateDHPrimes(256);
+        GenerateDHKeys(DHPrime, DHGenerator);
+    }
+    public HKeyExchange(int exponent, string modulus)
+        : this(exponent, modulus, string.Empty)
+    { }
+    public HKeyExchange(int exponent, string modulus, string privateExponent)
+    {
+        Exponent = new BigInteger(exponent);
+        Modulus = BigInteger.Parse("0" + modulus, NumberStyles.HexNumber);
 
-        public BigInteger DHPrime { get; private set; }
-        public BigInteger DHGenerator { get; private set; }
-
-        public bool CanDecrypt => (PrivateExponent != BigInteger.Zero);
-        public PKCSPadding Padding { get; set; } = PKCSPadding.MaxByte;
-
-        public HKeyExchange(int rsaKeySize)
+        var keys = new RSAParameters
         {
-            RSA = RSA.Create(rsaKeySize);
-            RSAParameters keys = RSA.ExportParameters(true);
+            Exponent = Exponent.ToByteArray(isBigEndian: true),
+            Modulus = Modulus.ToByteArray(isBigEndian: true)
+        };
 
-            Modulus = new BigInteger(keys.Modulus, true, true);
-            Exponent = new BigInteger(keys.Exponent, true, true);
-            PrivateExponent = new BigInteger(keys.D, true, true);
+        if (!string.IsNullOrWhiteSpace(privateExponent))
+        {
+            PrivateExponent = BigInteger.Parse("0" + privateExponent, NumberStyles.HexNumber);
+            keys.D = PrivateExponent.ToByteArray(isBigEndian: true);
 
             GenerateDHPrimes(256);
             GenerateDHKeys(DHPrime, DHGenerator);
         }
-        public HKeyExchange(int exponent, string modulus)
-            : this(exponent, modulus, string.Empty)
-        { }
-        public HKeyExchange(int exponent, string modulus, string privateExponent)
+
+        RSA = RSA.Create(keys);
+    }
+
+    public virtual string GetSignedP() => Sign(DHPrime);
+    public virtual string GetSignedG() => Sign(DHGenerator);
+
+    public virtual string GetPublicKey() 
+        => CanDecrypt ? Sign(DHPublic) : Encrypt(DHPublic);
+    public virtual byte[] GetSharedKey(string publicKey)
+    {
+        BigInteger bigInteger = CanDecrypt ? Decrypt(publicKey) : Verify(publicKey);
+        
+        byte[] sharedKey = BigInteger.ModPow(bigInteger, DHPrivate, DHPrime)
+            .ToByteArray(isBigEndian: true);
+
+        return sharedKey;
+    }
+    public virtual void VerifyDHPrimes(string p, string g)
+    {
+        DHPrime = Verify(p);
+        if (DHPrime <= 2)
         {
-            Exponent = new BigInteger(exponent);
-            Modulus = BigInteger.Parse("0" + modulus, NumberStyles.HexNumber);
+            throw new ArgumentException($"P cannot be less than, or equal to 2.\r\n{DHPrime}");
+        }
 
-            var keys = new RSAParameters
+        DHGenerator = Verify(g);
+        if (DHGenerator >= DHPrime)
+        {
+            throw new ArgumentException($"G cannot be greater than, or equal to P.\r\n{DHPrime}\r\n{DHGenerator}");
+        }
+
+        GenerateDHKeys(DHPrime, DHGenerator);
+    }
+
+    protected string Sign(BigInteger value)
+    {
+        return Encrypt(CalculatePrivate, value);
+    }
+    protected BigInteger Verify(string value)
+    {
+        return Decrypt(CalculatePublic, value);
+    }
+
+    protected string Encrypt(BigInteger value)
+    {
+        return Encrypt(CalculatePublic, value);
+    }
+    protected BigInteger Decrypt(string value)
+    {
+        return Decrypt(CalculatePrivate, value);
+    }
+
+    protected void PKCSPad(Span<byte> data, int padLength)
+    {
+        data[0] = (byte)Padding;
+        Span<byte> paddingData = data[1..padLength];
+
+        if (Padding == PKCSPadding.RandomByte)
+        {
+            for (int i = 0; i < paddingData.Length; i++)
             {
-                Exponent = Exponent.ToByteArray(isBigEndian: true),
-                Modulus = Modulus.ToByteArray(isBigEndian: true)
-            };
-
-            if (!string.IsNullOrWhiteSpace(privateExponent))
-            {
-                PrivateExponent = BigInteger.Parse("0" + privateExponent, NumberStyles.HexNumber);
-                keys.D = PrivateExponent.ToByteArray(isBigEndian: true);
-
-                GenerateDHPrimes(256);
-                GenerateDHKeys(DHPrime, DHGenerator);
+                paddingData[i] = (byte)RandomNumberGenerator.GetInt32(1, 256);
             }
-
-            RSA = RSA.Create(keys);
         }
+        else paddingData.Fill(byte.MaxValue);
 
-        public virtual string GetSignedP() => Sign(DHPrime);
-        public virtual string GetSignedG() => Sign(DHGenerator);
+        paddingData[^1] = 0;
+    }
+    protected void PKCSUnpad(ref Span<byte> data)
+    {
+        Padding = (PKCSPadding)data[0];
 
-        public virtual string GetPublicKey()
+        int dataStart = data.IndexOf((byte)0) + 1;
+        data = data[dataStart..];
+    }
+
+    protected BigInteger RandomInteger(int bitSize)
+    {
+        Span<byte> integerData = stackalloc byte[bitSize / 8];
+        RandomNumberGenerator.Fill(integerData);
+
+        integerData[^1] &= 0x7f;
+        return new BigInteger(integerData);
+    }
+
+    protected virtual void GenerateDHPrimes(int bitSize)
+    {
+        DHPrime = RandomInteger(bitSize);
+        DHGenerator = RandomInteger(bitSize);
+
+        if (DHGenerator > DHPrime)
+            (DHGenerator, DHPrime) = (DHPrime, DHGenerator);
+    }
+    protected virtual void GenerateDHKeys(BigInteger p, BigInteger g)
+    {
+        DHPrivate = RandomInteger(256);
+        DHPublic = BigInteger.ModPow(g, DHPrivate, p);
+    }
+
+    protected virtual string Encrypt(Func<BigInteger, BigInteger> calculator, BigInteger value)
+    {
+        Span<byte> valueData = stackalloc byte[BLOCK_SIZE - 1];
+        string valueStr = value.ToString();
+
+        // Writes the value string to the end of the buffer
+        int written = Encoding.UTF8.GetBytes(valueStr,
+            valueData[Index.FromEnd(valueStr.Length)..]);
+
+        // PKCS pad rest of the buffer
+        PKCSPad(valueData, valueData.Length - written);
+
+        var paddedInteger = new BigInteger(valueData, isBigEndian: true);
+        BigInteger calculatedInteger = calculator(paddedInteger);
+
+        return calculatedInteger.ToString("x").TrimStart('0');
+    }
+    protected virtual BigInteger Decrypt(Func<BigInteger, BigInteger> calculator, string value)
+    {
+        var signed = BigInteger.Parse("0" + value, NumberStyles.HexNumber);
+        BigInteger paddedInteger = calculator(signed);
+
+        Span<byte> valueData = stackalloc byte[paddedInteger.GetByteCount()];
+        paddedInteger.TryWriteBytes(valueData, out int bytesWritten, isBigEndian: true);
+
+        PKCSUnpad(ref valueData);
+        return BigInteger.Parse(Encoding.UTF8.GetString(valueData));
+    }
+
+    public virtual BigInteger CalculatePublic(BigInteger value)
+        => BigInteger.ModPow(value, Exponent, Modulus);
+    public virtual BigInteger CalculatePrivate(BigInteger value) 
+        => BigInteger.ModPow(value, PrivateExponent, Modulus);
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
         {
-            return (CanDecrypt ?
-                Sign(DHPublic) : Encrypt(DHPublic));
-        }
-        public virtual byte[] GetSharedKey(string publicKey)
-        {
-            BigInteger aKey = (CanDecrypt ?
-                Decrypt(publicKey) : Verify(publicKey));
-
-            byte[] sharedKey = BigInteger.ModPow(aKey,
-                DHPrivate, DHPrime).ToByteArray(isBigEndian: true);
-
-            return sharedKey;
-        }
-        public virtual void VerifyDHPrimes(string p, string g)
-        {
-            DHPrime = Verify(p);
-            if (DHPrime <= 2)
-            {
-                throw new ArgumentException(
-                    "P cannot be less than, or equal to 2.\r\n" + DHPrime, nameof(DHPrime));
-            }
-
-            DHGenerator = Verify(g);
-            if (DHGenerator >= DHPrime)
-            {
-                throw new ArgumentException(
-                    $"G cannot be greater than, or equal to P.\r\n{DHPrime}\r\n{DHGenerator}", nameof(DHGenerator));
-            }
-
-            GenerateDHKeys(DHPrime, DHGenerator);
-        }
-
-        protected string Sign(BigInteger value)
-        {
-            return Encrypt(CalculatePrivate, value);
-        }
-        protected BigInteger Verify(string value)
-        {
-            return Decrypt(CalculatePublic, value);
-        }
-
-        protected string Encrypt(BigInteger value)
-        {
-            return Encrypt(CalculatePublic, value);
-        }
-        protected BigInteger Decrypt(string value)
-        {
-            return Decrypt(CalculatePrivate, value);
-        }
-
-        protected void PKCSPad(Span<byte> data, int padLength)
-        {
-            data[0] = (byte)Padding;
-            Span<byte> paddingData = data[1..padLength];
-
-            if (Padding == PKCSPadding.RandomByte)
-            {
-                for (int i = 0; i < paddingData.Length; i++)
-                {
-                    paddingData[i] = (byte)_numberGenerator.Next(1, 256);
-                }
-            }
-            else paddingData.Fill(byte.MaxValue);
-
-            paddingData[^1] = 0;
-        }
-        protected Span<byte> PKCSUnpad(Span<byte> data)
-        {
-            Padding = (PKCSPadding)data[0];
-
-            int dataStart = data.IndexOf((byte)0) + 1;
-            return data.Slice(dataStart);
-        }
-
-        protected BigInteger RandomInteger(int bitSize)
-        {
-            Span<byte> integerData = stackalloc byte[bitSize / 8];
-            _numberGenerator.NextBytes(integerData);
-
-            integerData[^1] &= 0x7f;
-            return new BigInteger(integerData);
-        }
-
-        protected virtual void GenerateDHPrimes(int bitSize)
-        {
-            DHPrime = RandomInteger(bitSize);
-            DHGenerator = RandomInteger(bitSize);
-
-            if (DHGenerator > DHPrime)
-                (DHGenerator, DHPrime) = (DHPrime, DHGenerator);
-        }
-        protected virtual void GenerateDHKeys(BigInteger p, BigInteger g)
-        {
-            DHPrivate = RandomInteger(256);
-            DHPublic = BigInteger.ModPow(g, DHPrivate, p);
-        }
-
-        protected virtual string Encrypt(Func<BigInteger, BigInteger> calculator, BigInteger value)
-        {
-            Span<byte> valueData = stackalloc byte[BLOCK_SIZE - 1];
-            string valueStr = value.ToString();
-
-            //Writes the value string to the end of the buffer
-            int written = Encoding.UTF8.GetBytes(valueStr,
-                valueData[Index.FromEnd(valueStr.Length)..]);
-
-            //PKCS pad rest of the buffer
-            PKCSPad(valueData, (valueData.Length - written));
-
-            var paddedInteger = new BigInteger(valueData, isBigEndian: true);
-            BigInteger calculatedInteger = calculator(paddedInteger);
-
-            return calculatedInteger.ToString("x").TrimStart('0');
-        }
-        protected virtual BigInteger Decrypt(Func<BigInteger, BigInteger> calculator, string value)
-        {
-            var signed = BigInteger.Parse("0" + value, NumberStyles.HexNumber);
-            BigInteger paddedInteger = calculator(signed);
-
-            Span<byte> valueData = stackalloc byte[paddedInteger.GetByteCount()];
-            paddedInteger.TryWriteBytes(valueData, out int bytesWritten, isBigEndian: true);
-
-            valueData = PKCSUnpad(valueData);
-            return BigInteger.Parse(Encoding.UTF8.GetString(valueData));
-        }
-
-        public virtual BigInteger CalculatePublic(BigInteger value)
-        {
-            return BigInteger.ModPow(value, Exponent, Modulus);
-        }
-        public virtual BigInteger CalculatePrivate(BigInteger value)
-        {
-            return BigInteger.ModPow(value, PrivateExponent, Modulus);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                RSA.Dispose();
-            }
+            RSA.Dispose();
         }
     }
 }

--- a/Sulakore/Habbo/Enums/HHotel.cs
+++ b/Sulakore/Habbo/Enums/HHotel.cs
@@ -1,49 +1,49 @@
-﻿namespace Sulakore.Habbo
+﻿namespace Sulakore.Habbo;
+
+/// <summary>
+/// Specifies the list of hotels currently supported.
+/// </summary>
+public enum HHotel
 {
     /// <summary>
-    /// Specifies the list of hotels currently being supported.
+    /// Represents an unknown hotel.
     /// </summary>
-    public enum HHotel
-    {
-        /// <summary>
-        /// Represents an unknown hotel.
-        /// </summary>
-        Unknown = 0,
-        /// <summary>
-        /// Represents Habbo.com (North America).
-        /// </summary>
-        Com = 1,
-        /// <summary>
-        /// Represents Habbo.com.br (Brazil).
-        /// </summary>
-        ComBr = 2,
-        /// <summary>
-        /// Represents Habbo.com.tr (Turkey).
-        /// </summary>
-        ComTr = 3,
-        /// <summary>
-        /// Represents Habbo.de (Germany).
-        /// </summary>
-        De = 4,
-        /// <summary>
-        /// Represents Habbo.es (Spain).
-        /// </summary>
-        Es = 5,
-        /// <summary>
-        /// Represents Habbo.fi (Finland).
-        /// </summary>
-        Fi = 6,
-        /// <summary>
-        /// Represents Habbo.fr (France).
-        /// </summary>
-        Fr = 7,
-        /// <summary>
-        /// Represents Habbo.it (Italy).
-        /// </summary>
-        It = 8,
-        /// <summary>
-        /// Represents Habbo.nl (Netherlands).
-        /// </summary>
-        Nl = 9
-    }
+    Unknown = 0,
+
+    /// <summary>
+    /// Represents Habbo.com.
+    /// </summary>
+    US,
+    /// <summary>
+    /// Represents Habbo.fi (Finland).
+    /// </summary>
+    FI,
+    /// <summary>
+    /// Represents Habbo.es (Spain).
+    /// </summary>
+    ES,
+    /// <summary>
+    /// Represents Habbo.it (Italy).
+    /// </summary>
+    IT,
+    /// <summary>
+    /// Represents Habbo.nl (Netherlands).
+    /// </summary>
+    NL,
+    /// <summary>
+    /// Represents Habbo.de (Germany).
+    /// </summary>
+    DE,
+    /// <summary>
+    /// Represents Habbo.fr (France).
+    /// </summary>
+    FR,
+    /// <summary>
+    /// Represents Habbo.com.br (Brazil).
+    /// </summary>
+    BR,
+    /// <summary>
+    /// Represents Habbo.com.tr (Turkey).
+    /// </summary>
+    TR
 }

--- a/Sulakore/Habbo/HExtensions.cs
+++ b/Sulakore/Habbo/HExtensions.cs
@@ -1,66 +1,102 @@
 ﻿using System.Reflection;
 
-namespace Sulakore.Habbo
+namespace Sulakore.Habbo;
+
+public static class HExtensions
 {
-    public static class HExtensions
+    private static readonly Random _rng = new();
+    private const BindingFlags BINDINGS = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+
+    public static HSign GetRandomSign()
     {
-        private static readonly Random _rng = new Random();
-        private const BindingFlags BINDINGS = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+        return (HSign)_rng.Next(0, 19);
+    }
+    public static HTheme GetRandomTheme()
+    {
+        return (HTheme)((_rng.Next(1, 7) + 2) & 7);
+    }
 
-        public static HSign GetRandomSign()
+    public static HDirection ToLeft(this HDirection facing)
+    {
+        return (HDirection)(((int)facing - 1) & 7);
+    }
+    public static HDirection ToRight(this HDirection facing)
+    {
+        return (HDirection)(((int)facing + 1) & 7);
+    }
+
+    public static HHotel ToHotel(this ReadOnlySpan<char> value)
+    {
+        if (value.Length < 2) return HHotel.Unknown;
+
+        if (value.StartsWith("hh", StringComparison.OrdinalIgnoreCase)) value = value[2..4];
+        else if (value.StartsWith("game-", StringComparison.OrdinalIgnoreCase)) value = value[5..7];
+
+        if (value.Length != 2 && value.Length != 5)
         {
-            return (HSign)_rng.Next(0, 19);
-        }
-        public static HTheme GetRandomTheme()
-        {
-            return (HTheme)((_rng.Next(1, 7) + 2) & 7);
+            // Slice to the domain
+            int hostIndex = value.LastIndexOf("habbo", StringComparison.OrdinalIgnoreCase);
+            if (hostIndex != -1)
+                value = value[(hostIndex + "habbo".Length)..];
+
+            // Is second-level .com TLD
+            int comDotIndex = value.IndexOf("com.", StringComparison.OrdinalIgnoreCase);
+            if (comDotIndex != -1)
+                value = value[(comDotIndex + "com.".Length)..];
+            
+            // Corner-case where value was domain including the dot
+            if (value[0] == '.') value = value[1..];
+
+            if (value.StartsWith("com", StringComparison.OrdinalIgnoreCase))
+                return HHotel.US;
+            
+            // Slice out rest of value
+            value = value[..2];
         }
 
-        public static HDirection ToLeft(this HDirection facing)
-        {
-            return (HDirection)(((int)facing - 1) & 7);
-        }
-        public static HDirection ToRight(this HDirection facing)
-        {
-            return (HDirection)(((int)facing + 1) & 7);
-        }
+        if (Enum.TryParse(value, ignoreCase: true, out HHotel hotel))
+            return hotel;
 
-        public static string ToDomain(this HHotel hotel)
-        {
-            if (hotel == HHotel.Unknown)
-            {
-                throw new ArgumentException("Hotel cannot be 'Unknown'.", nameof(hotel));
-            }
-            string value = hotel.ToString().ToLower();
-            return value.Length != 5 ? value : value.Insert(3, ".");
-        }
-        public static Uri ToUri(this HHotel hotel, string subdomain = "www")
-        {
-            return new Uri($"https://{subdomain}.habbo.{hotel.ToDomain()}");
-        }
+        return HHotel.Unknown;
+    }
 
-        public static IEnumerable<MemberInfo> GetAllMembers(this Type type)
+    public static string ToRegion(this HHotel hotel) 
+        => hotel.ToString().ToLower();
+    public static string ToDomain(this HHotel hotel)
+        => hotel switch
         {
-            return type.Excavate(t => t.GetMembers(BINDINGS));
-        }
-        public static IEnumerable<MethodInfo> GetAllMethods(this Type type)
+            HHotel.TR => "com.tr",
+            HHotel.BR => "com.br",
+            HHotel.Unknown => throw new ArgumentException($"Hotel cannot be '{nameof(HHotel.Unknown)}'.", nameof(hotel)),
+            
+            _ => hotel.ToString().ToLower()
+        };
+    public static Uri ToUri(this HHotel hotel, string subdomain = "www")
+    {
+        return new Uri($"https://{subdomain}.habbo.{hotel.ToDomain()}");
+    }
+
+    public static IEnumerable<MemberInfo> GetAllMembers(this Type type)
+    {
+        return type.Excavate(t => t.GetMembers(BINDINGS));
+    }
+    public static IEnumerable<MethodInfo> GetAllMethods(this Type type)
+    {
+        return type.Excavate(t => t.GetMethods(BINDINGS));
+    }
+    public static IEnumerable<PropertyInfo> GetAllProperties(this Type type)
+    {
+        return type.Excavate(t => t.GetProperties(BINDINGS));
+    }
+    public static IEnumerable<T> Excavate<T>(this Type type, Func<Type, IEnumerable<T>> excavator)
+    {
+        IEnumerable<T> excavated = null;
+        while (type != null)
         {
-            return type.Excavate(t => t.GetMethods(BINDINGS));
+            IEnumerable<T> batch = excavator(type);
+            excavated = excavated?.Concat(batch) ?? batch;
+            type = type.BaseType;
         }
-        public static IEnumerable<PropertyInfo> GetAllProperties(this Type type)
-        {
-            return type.Excavate(t => t.GetProperties(BINDINGS));
-        }
-        public static IEnumerable<T> Excavate<T>(this Type type, Func<Type, IEnumerable<T>> excavator)
-        {
-            IEnumerable<T> excavated = null;
-            while (type != null)
-            {
-                IEnumerable<T> batch = excavator(type);
-                excavated = excavated?.Concat(batch) ?? batch;
-                type = type.BaseType;
-            }
-            return excavated;
-        }
+        return excavated;
     }
 }

--- a/Sulakore/Habbo/HPoint.cs
+++ b/Sulakore/Habbo/HPoint.cs
@@ -1,16 +1,62 @@
 ﻿using System.Drawing;
+using System.Numerics;
 
 namespace Sulakore.Habbo;
 
+/// <summary>
+/// Represents an ordered pair of x-, y-, and z- coordinates that defines a point in a three-dimensional space.
+/// </summary>
 public struct HPoint : IEquatable<HPoint>, ISpanFormattable
 {
-    public static readonly HPoint Empty;
-    
-    public int X { get; init; }
-    public int Y { get; init; }
-    public double Z { get; init; }
+    public const float DEFAULT_EPSILON = 0.01f;
 
-    public readonly bool IsEmpty => Equals(Empty);
+    public static readonly HPoint Zero = new();
+    
+    public int X { readonly get; init; }
+    public int Y { readonly get; init; }
+    public float Z { readonly get; init; }
+
+    public HPoint()
+        : this(0, 0, 0)
+    { }
+    public HPoint(int x, int y)
+        : this(x, y, 0)
+    { }
+    public HPoint(int x, int y, char level)
+        : this(x, y, ToZ(level))
+    { }
+    public HPoint(int x, int y, float z)
+        => (X, Y, Z) = (x, y, z);
+
+    public readonly override string ToString()
+        => ToString(format: null);
+    
+    public readonly override int GetHashCode() => HashCode.Combine(X, Y, Z);
+    public readonly override bool Equals(object obj)
+    {
+        if (obj is HPoint other)
+            return Equals(other);
+        else if (obj is ValueTuple<int, int> t2)
+            return Equals(t2);
+        else if (obj is ValueTuple<int, int, float> t3)
+            return Equals(t3);
+        else return false;
+    }
+
+    public readonly bool Equals(HPoint other) => Equals(other);
+    public readonly bool Equals(HPoint other, float epsilon = DEFAULT_EPSILON) => X == other.X && Y == other.Y
+        && Math.Abs(other.Z - Z) < epsilon;
+
+    public readonly bool Equals((int X, int Y) point) => X == point.X && Y == point.Y;
+    public readonly bool Equals((int X, int Y, int Z) point, float epsilon = DEFAULT_EPSILON) => X == point.X && Y == point.Y
+        && Math.Abs(point.Z - Z) < epsilon;
+    public readonly bool Equals((int X, int Y, float Z) point, float epsilon = DEFAULT_EPSILON) => X == point.X && Y == point.Y 
+        && Math.Abs(point.Z - Z) < epsilon;
+
+    public readonly bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider provider = default)
+        => destination.TryWrite($"{X}, {Y}, {Z}", out charsWritten);
+    public readonly string ToString(string format, IFormatProvider formatProvider = default)
+        => string.Create(formatProvider, $"{X}, {Y}, {Z}");
 
     public static bool operator !=(HPoint left, HPoint right) => !(left == right);
     public static bool operator ==(HPoint left, HPoint right) => left.Equals(right);
@@ -18,40 +64,32 @@ public struct HPoint : IEquatable<HPoint>, ISpanFormattable
     public static implicit operator Point(HPoint point) => new(point.X, point.Y);
     public static implicit operator HPoint(Point point) => new(point.X, point.Y);
 
-    public static implicit operator (int x, int y)(HPoint point) => (point.X, point.Y);
-    public static implicit operator (int x, int y, double z)(HPoint point) => (point.X, point.Y, point.Z);
+    public static implicit operator Vector2(HPoint point) => new(point.X, point.Y);
+    public static implicit operator Vector3(HPoint point) => new(point.X, point.Y, point.Z);
 
-    public static implicit operator HPoint((int x, int y) point) => new(point.x, point.y);
-    public static implicit operator HPoint((int x, int y, double z) point) => new(point.x, point.y, point.z);
+    public static implicit operator (int X, int Y)(HPoint point) => (point.X, point.Y);
+    public static implicit operator (int X, int Y, float Z)(HPoint point) => (point.X, point.Y, point.Z);
 
-    public HPoint(int x, int y)
-        : this(x, y, 0)
-    { }
-    public HPoint(int x, int y, char level)
-        : this(x, y, ToZ(level))
-    { }
-    public HPoint(int x, int y, double z)
-        => (X, Y, Z) = (x, y, z);
+    public static implicit operator HPoint((int X, int Y) point) => new(point.X, point.Y);
+    public static implicit operator HPoint((int X, int Y, float Z) point) => new(point.X, point.Y, point.Z);
 
-    public readonly override int GetHashCode() => HashCode.Combine(X, Y);
+    public static HPoint operator +(HPoint point, (int X, int Y) offset) => new(point.X + offset.X, point.Y + offset.Y);
+    public static HPoint operator +(HPoint point, (int X, int Y, int Z) offset) => new(point.X + offset.X, point.Y + offset.Y, point.Z + offset.Z);
+    public static HPoint operator +(HPoint point, (int X, int Y, float Z) offset) => new(point.X + offset.X, point.Y + offset.Y, point.Z + offset.Z);
+    public static HPoint operator +(HPoint left, HPoint right) => new(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
 
-    public readonly bool Equals(HPoint point) => X == point.X && Y == point.Y;
-    public readonly override bool Equals(object obj) => obj is HPoint point && Equals(point);
+    public static HPoint operator -(HPoint point, (int X, int Y) offset) => new(point.X - offset.X, point.Y - offset.Y);
+    public static HPoint operator -(HPoint point, (int X, int Y, int Z) offset) => new(point.X - offset.X, point.Y - offset.Y, point.Z - offset.Z);
+    public static HPoint operator -(HPoint point, (int X, int Y, float Z) offset) => new(point.X - offset.X, point.Y - offset.Y, point.Z - offset.Z);
+    public static HPoint operator -(HPoint left, HPoint right) => new(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
 
-    public readonly bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
-        => destination.TryWrite($"X={X}, Y={Y}, Z={Z}", out charsWritten);
-
-    public readonly string ToString(string format, IFormatProvider formatProvider)
-        => string.Create(formatProvider, $"X={X}, Y={Y}, Z={Z}");
-    public readonly override string ToString() => ToString();
-
-    public static char ToLevel(double z)
+    public static char ToLevel(float z)
     {
         if (z >= 0 && z <= 9) return (char)(z + 48);
         if (z >= 10 && z <= 29) return (char)(z + 87);
         return 'x';
     }
-    public static double ToZ(char level)
+    public static float ToZ(char level)
     {
         if (level >= '0' && level <= '9') return level - 48;
         if (level >= 'a' && level <= 't') return level - 87;

--- a/Sulakore/Habbo/HPoint.cs
+++ b/Sulakore/Habbo/HPoint.cs
@@ -1,60 +1,60 @@
 ﻿using System.Drawing;
-using System.Diagnostics;
 
-namespace Sulakore.Habbo
+namespace Sulakore.Habbo;
+
+public struct HPoint : IEquatable<HPoint>, ISpanFormattable
 {
-    [DebuggerDisplay(@"\{X = {X} Y = {Y} Z = {Z}\}")]
-    public struct HPoint : IEquatable<HPoint>
+    public static readonly HPoint Empty;
+    
+    public int X { get; init; }
+    public int Y { get; init; }
+    public double Z { get; init; }
+
+    public readonly bool IsEmpty => Equals(Empty);
+
+    public static bool operator !=(HPoint left, HPoint right) => !(left == right);
+    public static bool operator ==(HPoint left, HPoint right) => left.Equals(right);
+
+    public static implicit operator Point(HPoint point) => new(point.X, point.Y);
+    public static implicit operator HPoint(Point point) => new(point.X, point.Y);
+
+    public static implicit operator (int x, int y)(HPoint point) => (point.X, point.Y);
+    public static implicit operator (int x, int y, double z)(HPoint point) => (point.X, point.Y, point.Z);
+
+    public static implicit operator HPoint((int x, int y) point) => new(point.x, point.y);
+    public static implicit operator HPoint((int x, int y, double z) point) => new(point.x, point.y, point.z);
+
+    public HPoint(int x, int y)
+        : this(x, y, 0)
+    { }
+    public HPoint(int x, int y, char level)
+        : this(x, y, ToZ(level))
+    { }
+    public HPoint(int x, int y, double z)
+        => (X, Y, Z) = (x, y, z);
+
+    public readonly override int GetHashCode() => HashCode.Combine(X, Y);
+
+    public readonly bool Equals(HPoint point) => X == point.X && Y == point.Y;
+    public readonly override bool Equals(object obj) => obj is HPoint point && Equals(point);
+
+    public readonly bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+        => destination.TryWrite($"X={X}, Y={Y}, Z={Z}", out charsWritten);
+
+    public readonly string ToString(string format, IFormatProvider formatProvider)
+        => string.Create(formatProvider, $"X={X}, Y={Y}, Z={Z}");
+    public readonly override string ToString() => ToString();
+
+    public static char ToLevel(double z)
     {
-        public int X { get; set; }
-        public int Y { get; set; }
-        public double Z { get; set; }
-        public readonly bool IsEmpty => Equals(Empty);
-
-        public static readonly HPoint Empty;
-
-        public static bool operator !=(HPoint left, HPoint right) => !(left == right);
-        public static bool operator ==(HPoint left, HPoint right) => left.Equals(right);
-
-        public static implicit operator Point(HPoint point) => new Point(point.X, point.Y);
-        public static implicit operator HPoint(Point point) => new HPoint(point.X, point.Y);
-
-        public static implicit operator (int x, int y)(HPoint point) => (point.X, point.Y);
-        public static implicit operator (int x, int y, double z)(HPoint point) => (point.X, point.Y, point.Z);
-
-        public static implicit operator HPoint((int x, int y) point) => new HPoint(point.x, point.y);
-        public static implicit operator HPoint((int x, int y, double z) point) => new HPoint(point.x, point.y, point.z);
-
-        public HPoint(int x, int y)
-            : this(x, y, 0)
-        { }
-        public HPoint(int x, int y, double z)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
-        public HPoint(int x, int y, char level)
-            : this(x, y, ToZ(level))
-        { }
-
-        public readonly override int GetHashCode() => HashCode.Combine(X, Y);
-        public readonly override string ToString() => $"{{X={X},Y={Y},Z={Z}}}";
-
-        public readonly bool Equals(HPoint point) => X == point.X && Y == point.Y;
-        public readonly override bool Equals(object obj) => obj is HPoint point && Equals(point);
-
-        public static char ToLevel(double z)
-        {
-            if (z >= 0 && z <= 9) return (char)(z + 48);
-            if (z >= 10 && z <= 29) return (char)(z + 87);
-            return 'x';
-        }
-        public static double ToZ(char level)
-        {
-            if (level >= '0' && level <= '9') return level - 48;
-            if (level >= 'a' && level <= 't') return level - 87;
-            return 0;
-        }
+        if (z >= 0 && z <= 9) return (char)(z + 48);
+        if (z >= 10 && z <= 29) return (char)(z + 87);
+        return 'x';
+    }
+    public static double ToZ(char level)
+    {
+        if (level >= '0' && level <= '9') return level - 48;
+        if (level >= 'a' && level <= 't') return level - 87;
+        return 0;
     }
 }

--- a/Sulakore/Habbo/Web/HAPI.cs
+++ b/Sulakore/Habbo/Web/HAPI.cs
@@ -2,111 +2,104 @@
 using System.Text.Json;
 using System.Net.Http.Json;
 
-using Sulakore.Network;
 using Sulakore.Habbo.Web.Json;
 
-namespace Sulakore.Habbo.Web
+namespace Sulakore.Habbo.Web;
+
+public static class HAPI
 {
-    public static class HAPI
+    private static readonly HttpClient _client;
+    private static readonly HttpClientHandler _handler;
+
+    public static CookieContainer Cookies
     {
-        private static readonly HttpClient _client;
-        private static readonly HttpClientHandler _handler;
+        get => _handler.CookieContainer;
+        set => _handler.CookieContainer = value;
+    }
+    public static JsonSerializerOptions SerializerOptions { get; }
 
-        public static CookieContainer Cookies
+    static HAPI()
+    {
+        _handler = new HttpClientHandler
         {
-            get => _handler.CookieContainer;
-            set => _handler.CookieContainer = value;
-        }
-        public static JsonSerializerOptions SerializerOptions { get; }
+            UseProxy = false,
+            AutomaticDecompression = DecompressionMethods.All
+        };
 
-        static HAPI()
+        _client = new HttpClient(_handler);
+        _client.DefaultRequestHeaders.ConnectionClose = true;
+        _client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 Edg/92.0.902.67");
+
+        SerializerOptions = new JsonSerializerOptions
         {
-            _handler = new HttpClientHandler
-            {
-                UseProxy = false,
-                AutomaticDecompression = DecompressionMethods.All
-            };
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        SerializerOptions.Converters.Add(new DateTimeConverter());
+    }
 
-            _client = new HttpClient(_handler);
-            _client.DefaultRequestHeaders.ConnectionClose = true;
-            _client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 Edg/92.0.902.67");
+    public static Task<byte[]> GetFigureDataAsync(string query) => ReadContentAsync<byte[]>(HHotel.US.ToUri(), "/habbo-imaging/avatarimage?" + query);
+    public static Task<HUser> GetUserAsync(string name, HHotel hotel) => ReadContentAsync<HUser>(hotel.ToUri(), "/api/public/users?name=" + name);
+    public static Task<HProfile> GetProfileAsync(string uniqueId) => ReadContentAsync<HProfile>(uniqueId.AsSpan().ToHotel().ToUri(), $"/api/public/users/{uniqueId}/profile");
 
-            SerializerOptions = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-            SerializerOptions.Converters.Add(new DateTimeConverter());
-        }
-
-        public static Task<byte[]> GetFigureDataAsync(string query) => ReadContentAsync<byte[]>(HHotel.Com.ToUri(), "/habbo-imaging/avatarimage?" + query);
-        public static Task<HUser> GetUserAsync(string name, HHotel hotel) => ReadContentAsync<HUser>(hotel.ToUri(), "/api/public/users?name=" + name);
-        public static Task<HProfile> GetProfileAsync(string uniqueId) => ReadContentAsync<HProfile>(HotelEndPoint.GetHotel(uniqueId).ToUri(), $"/api/public/users/{uniqueId}/profile");
-
-        public static async Task<string> GetLatestRevisionAsync(HHotel hotel)
+    public static async Task<string> GetLatestRevisionAsync(HHotel hotel)
+    {
+        string body = await ReadContentAsync<string>(hotel.ToUri(), "/gamedata/external_variables/1").ConfigureAwait(false);
+        int revisionStartIndex = body.LastIndexOf("/gordon/") + 8;
+        if (revisionStartIndex != 7)
         {
-            string body = await ReadContentAsync<string>(hotel.ToUri(), "/gamedata/external_variables/1").ConfigureAwait(false);
-            int revisionStartIndex = body.LastIndexOf("/gordon/") + 8;
-            if (revisionStartIndex != 7)
+            int revisionEndIndex = body.IndexOf('/', revisionStartIndex);
+            if (revisionEndIndex != -1)
             {
-                int revisionEndIndex = body.IndexOf('/', revisionStartIndex);
-                if (revisionEndIndex != -1)
-                {
-                    return body[revisionStartIndex..revisionEndIndex];
-                }
+                return body[revisionStartIndex..revisionEndIndex];
             }
-            return null;
         }
-        public static async Task<HProfile> GetProfileAsync(string name, HHotel hotel)
+        return null;
+    }
+    public static async Task<HProfile> GetProfileAsync(string name, HHotel hotel)
+    {
+        HUser user = await GetUserAsync(name, hotel).ConfigureAwait(false);
+        if (user.ProfileVisible == true)
         {
-            HUser user = await GetUserAsync(name, hotel).ConfigureAwait(false);
-            if (user.ProfileVisible == true)
-            {
-                return await GetProfileAsync(user.UniqueId).ConfigureAwait(false);
-            }
-            return new HProfile { User = user };
+            return await GetProfileAsync(user.UniqueId).ConfigureAwait(false);
         }
+        return new HProfile { User = user };
+    }
 
-        public static async Task<T> ReadContentAsync<T>(Uri baseUri, string path, Func<HttpContent, Task<T>> contentConverter = null)
+    public static async Task<T> ReadContentAsync<T>(Uri baseUri, string path, Func<HttpContent, Task<T>> contentConverter = null)
+    {
+        string uriAuthority = baseUri.GetLeftPart(UriPartial.Authority);
+        using HttpRequestMessage request = new(HttpMethod.Get, uriAuthority + path);
+        if (!string.IsNullOrWhiteSpace(path))
         {
-            ServicePointManager.FindServicePoint(baseUri).ConnectionLeaseTimeout = 0;
-
-            string uriAuthority = baseUri.GetLeftPart(UriPartial.Authority);
-            using HttpRequestMessage request = new(HttpMethod.Get, uriAuthority + path);
-            if (!string.IsNullOrWhiteSpace(path))
-            {
-                request.Headers.Add("Referer", uriAuthority);
-            }
-
-            using HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode) return default;
-
-            if (contentConverter != null)
-                return await contentConverter(response.Content).ConfigureAwait(false);
-
-            Type genericType = typeof(T);
-
-            if (genericType == typeof(string))
-                return (T)(object)await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            if (genericType == typeof(byte[]))
-                return (T)(object)await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-
-            if (response.Content.Headers.ContentType.MediaType == "application/json")
-                return await response.Content.ReadFromJsonAsync<T>(SerializerOptions).ConfigureAwait(false);
-
-            return default;
+            request.Headers.Add("Referer", uriAuthority);
         }
 
-        private static Task<HttpResponseMessage> SendMessageAsync(HHotel hotel, string path, HttpMethod method)
+        using HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode) return default;
+
+        if (contentConverter != null)
+            return await contentConverter(response.Content).ConfigureAwait(false);
+
+        if (typeof(T) == typeof(string))
+            return (T)(object)await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+        if (typeof(T) == typeof(byte[]))
+            return (T)(object)await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+        if (response.Content.Headers.ContentType.MediaType == "application/json")
+            return await response.Content.ReadFromJsonAsync<T>(SerializerOptions).ConfigureAwait(false);
+
+        return default;
+    }
+
+    private static Task<HttpResponseMessage> SendMessageAsync(HHotel hotel, string path, HttpMethod method)
+    {
+        string uriAuthority = hotel.ToUri().GetLeftPart(UriPartial.Authority);
+        HttpRequestMessage requestMsg = new(method, uriAuthority + path);
+        if (!string.IsNullOrWhiteSpace(path))
         {
-            string uriAuthority = hotel.ToUri().GetLeftPart(UriPartial.Authority);
-            HttpRequestMessage requestMsg = new(method, uriAuthority + path);
-            if (!string.IsNullOrWhiteSpace(path))
-            {
-                requestMsg.Headers.Add("Referer", uriAuthority);
-            }
-            ServicePointManager.FindServicePoint(requestMsg.RequestUri).ConnectionLeaseTimeout = 0;
-            return _client.SendAsync(requestMsg);
+            requestMsg.Headers.Add("Referer", uriAuthority);
         }
+        return _client.SendAsync(requestMsg);
     }
 }

--- a/Sulakore/Network/HotelEndPoint.cs
+++ b/Sulakore/Network/HotelEndPoint.cs
@@ -2,91 +2,44 @@
 
 using Sulakore.Habbo;
 
-namespace Sulakore.Network
+namespace Sulakore.Network;
+
+public class HotelEndPoint : IPEndPoint
 {
-    public class HotelEndPoint : IPEndPoint
+    public string Host { get; init; }
+    public HHotel Hotel { get; init; }
+
+    public HotelEndPoint(IPEndPoint endPoint)
+        : base(endPoint.Address, endPoint.Port)
+    { }
+    public HotelEndPoint(long address, int port)
+        : base(address, port)
+    { }
+    public HotelEndPoint(IPAddress address, int port)
+        : base(address, port)
+    { }
+    public HotelEndPoint(IPAddress address, int port, string host)
+        : base(address, port)
     {
-        public string Host { get; init; }
-        public HHotel Hotel { get; init; }
+        Host = host;
+    }
 
-        public HotelEndPoint(IPEndPoint endPoint)
-            : base(endPoint.Address, endPoint.Port)
-        { }
-        public HotelEndPoint(long address, int port)
-            : base(address, port)
-        { }
-        public HotelEndPoint(IPAddress address, int port)
-            : base(address, port)
-        { }
-        public HotelEndPoint(IPAddress address, int port, string host)
-            : base(address, port)
-        {
-            Host = host;
-        }
+    public static HotelEndPoint Create(ReadOnlySpan<char> host) => Create(host.ToHotel());
+    public static HotelEndPoint Create(HHotel hotel) => hotel != HHotel.Unknown ? Parse($"game-{hotel.ToRegion()}.habbo.com", 30001) : null;
 
-        public static HHotel GetHotel(string value)
-        {
-            if (string.IsNullOrWhiteSpace(value) || value.Length < 2) return HHotel.Unknown;
-            if (value.StartsWith("hh")) value = value[2..4];
-            if (value.StartsWith("game-")) value = value[5..7];
+    public static HotelEndPoint Parse(string host, int port)
+    {
+        IPAddress[] ips = Dns.GetHostAddresses(host);
+        return new HotelEndPoint(ips[0], port, host) { Host = host, Hotel = host.AsSpan().ToHotel() };
+    }
+    public static async Task<HotelEndPoint> ParseAsync(string host, int port, CancellationToken cancellationToken = default)
+    {
+        IPAddress[] ips = await Dns.GetHostAddressesAsync(host, cancellationToken).ConfigureAwait(false);
+        return new HotelEndPoint(ips[0], port, host) { Host = host, Hotel = host.AsSpan().ToHotel() };
+    }
 
-            switch (value)
-            {
-                case "us": return HHotel.Com;
-                case "br": return HHotel.ComBr;
-                case "tr": return HHotel.ComTr;
-                default:
-                {
-                    if (value.Length != 2 && value.Length != 5)
-                    {
-                        int hostIndex = value.LastIndexOf("habbo");
-                        if (hostIndex != -1)
-                        {
-                            value = value[(hostIndex + 5)..];
-                        }
-
-                        int comDotIndex = value.IndexOf("com.");
-                        if (comDotIndex != -1)
-                        {
-                            value = value.Remove(comDotIndex + 3, 1);
-                        }
-
-                        if (value[0] == '.') value = value[1..];
-                        if (value.Length != 3)
-                        {
-                            value = value.Substring(0, value.StartsWith("com") ? 5 : 2);
-                        }
-                    }
-                    if (Enum.TryParse(value, true, out HHotel hotel) && Enum.IsDefined(typeof(HHotel), hotel)) return hotel;
-                    break;
-                }
-            }
-            return HHotel.Unknown;
-        }
-        public static string GetRegion(HHotel hotel) => hotel switch
-        {
-            HHotel.Com => "us",
-            HHotel.ComBr => "br",
-            HHotel.ComTr => "tr",
-            _ => hotel.ToString().ToLower(),
-        };
-
-        public static HotelEndPoint Create(string host) => Create(GetHotel(host));
-        public static HotelEndPoint Create(HHotel hotel) => hotel != HHotel.Unknown ? Parse($"game-{GetRegion(hotel)}.habbo.com", 30001) : null;
-
-        public static HotelEndPoint Parse(string host, int port)
-        {
-            return ParseAsync(host, port).Result;
-        }
-        public static async Task<HotelEndPoint> ParseAsync(string host, int port)
-        {
-            IPAddress[] ips = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            return new HotelEndPoint(ips[0], port, host) { Host = host, Hotel = GetHotel(host) };
-        }
-
-        public override string ToString()
-        {
-            return $"{(string.IsNullOrWhiteSpace(Host) ? Address.ToString() : Host)}:{Port}";
-        }
+    public override string ToString()
+    {
+        return $"{(string.IsNullOrWhiteSpace(Host) ? Address.ToString() : Host)}:{Port}";
     }
 }


### PR DESCRIPTION
- Use secure RNG (if available to OS) instead of pseudo-random in `HKeyExchange`
- Bunch of HPoint changes
    - Make Z -coordinate to float type. Double-precision is not used in-game anywhere.
    - Easy `ISpanFormattable` implementation for potential gains when formatting large amounts of points
    - Add addition and subtraction math operations which allow very simple coordinate manipulations. 
    - Added new comparison overloads which now allow to API consumer to compare coordinates in three dimensions.
    - Added implicit casts to `Vector2` and `Vector2` for very cool math operations (These types are extremely powerful and have hardware-acceleration when available).
 - Move the `HHotel` parsing logic `HExtension` and spanify it.
 - Rename `HHotel` enum values which we agreed are better.
 - Minor general refactor to HotelEndPoint