### PR TITLE
Use source generators for HAPI JSON deserialization

### DIFF
--- a/Sulakore/Habbo/Web/HAPI.cs
+++ b/Sulakore/Habbo/Web/HAPI.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Text.Json;
 using System.Net.Http.Json;
 
 using Sulakore.Habbo.Web.Json;
@@ -16,34 +15,26 @@ public static class HAPI
         get => _handler.CookieContainer;
         set => _handler.CookieContainer = value;
     }
-    public static JsonSerializerOptions SerializerOptions { get; }
 
     static HAPI()
     {
         _handler = new HttpClientHandler
         {
-            UseProxy = false,
-            AutomaticDecompression = DecompressionMethods.All
+            UseProxy = false
         };
 
         _client = new HttpClient(_handler);
         _client.DefaultRequestHeaders.ConnectionClose = true;
-        _client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 Edg/92.0.902.67");
-
-        SerializerOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-        };
-        SerializerOptions.Converters.Add(new DateTimeConverter());
+        _client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36");
     }
 
-    public static Task<byte[]?> GetFigureDataAsync(string query) => ReadContentAsync<byte[]?>(HHotel.US.ToUri(), "/habbo-imaging/avatarimage?" + query);
-    public static Task<HUser?> GetUserAsync(string name, HHotel hotel) => ReadContentAsync<HUser?>(hotel.ToUri(), "/api/public/users?name=" + name);
-    public static Task<HProfile?> GetProfileAsync(string uniqueId) => ReadContentAsync<HProfile?>(uniqueId.AsSpan().ToHotel().ToUri(), $"/api/public/users/{uniqueId}/profile");
+    public static Task<byte[]?> GetFigureDataAsync(string query, CancellationToken cancellationToken = default) => GetAsync<byte[]?>(HHotel.US.ToUri(), "/habbo-imaging/avatarimage?" + query, cancellationToken);
+    public static Task<HUser?> GetUserAsync(string name, HHotel hotel, CancellationToken cancellationToken = default) => GetAsync<HUser?>(hotel.ToUri(), "/api/public/users?name=" + name, cancellationToken);
+    public static Task<HProfile?> GetProfileAsync(string uniqueId, CancellationToken cancellationToken = default) => GetAsync<HProfile?>(uniqueId.AsSpan().ToHotel().ToUri(), $"/api/public/users/{uniqueId}/profile", cancellationToken);
 
-    public static async Task<string?> GetLatestRevisionAsync(HHotel hotel)
+    public static async Task<string?> GetLatestRevisionAsync(HHotel hotel, CancellationToken cancellationToken = default)
     {
-        string? body = await ReadContentAsync<string?>(hotel.ToUri(), "/gamedata/external_variables/1").ConfigureAwait(false);
+        string? body = await GetAsync<string?>(hotel.ToUri(), "/gamedata/external_variables/1", cancellationToken).ConfigureAwait(false);
         if (body == null) return null;
         
         int revisionStartIndex = body.LastIndexOf("/gordon/") + 8;
@@ -57,17 +48,19 @@ public static class HAPI
         }
         return null;
     }
-    public static async Task<HProfile?> GetProfileAsync(string name, HHotel hotel)
+    public static async Task<HProfile?> GetProfileAsync(string name, HHotel hotel, CancellationToken cancellationToken = default)
     {
-        HUser? user = await GetUserAsync(name, hotel).ConfigureAwait(false);
+        HUser? user = await GetUserAsync(name, hotel, cancellationToken).ConfigureAwait(false);
         if (user?.ProfileVisible == true)
         {
-            return await GetProfileAsync(user.UniqueId).ConfigureAwait(false);
+            return await GetProfileAsync(user.UniqueId, cancellationToken).ConfigureAwait(false);
         }
         return new HProfile { User = user };
     }
 
-    public static async Task<T?> ReadContentAsync<T>(Uri baseUri, string path, Func<HttpContent, Task<T>>? contentConverter = null)
+    public static async Task<T?> GetAsync<T>(Uri baseUri, string path,
+        CancellationToken cancellationToken = default,
+        Func<HttpContent, CancellationToken, Task<T>>? contentConverter = null)
     {
         string uriAuthority = baseUri.GetLeftPart(UriPartial.Authority);
         using HttpRequestMessage request = new(HttpMethod.Get, uriAuthority + path);
@@ -76,21 +69,21 @@ public static class HAPI
             request.Headers.Add("Referer", uriAuthority);
         }
 
-        using HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+        using HttpResponseMessage response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) return default;
 
         if (contentConverter != null)
-            return await contentConverter(response.Content).ConfigureAwait(false);
+            return await contentConverter(response.Content, cancellationToken).ConfigureAwait(false);
 
         if (typeof(T) == typeof(string))
-            return (T)(object)await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return (T)(object)await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (typeof(T) == typeof(byte[]))
-            return (T)(object)await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            return (T)(object)await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 
         if (response.Content.Headers.ContentType?.MediaType == "application/json")
-            return await response.Content.ReadFromJsonAsync<T>(SerializerOptions).ConfigureAwait(false);
-
+            return (T?)await response.Content.ReadFromJsonAsync(typeof(T), HJsonContext.Default, cancellationToken).ConfigureAwait(false);
+        
         return default;
     }
 

--- a/Sulakore/Habbo/Web/HRoom.cs
+++ b/Sulakore/Habbo/Web/HRoom.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using Sulakore.Habbo.Web.Json;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
 
 namespace Sulakore.Habbo.Web;
 
@@ -9,6 +11,7 @@ public class HRoom
     public string Name { get; set; }
     public string Description { get; set; }
 
+    [JsonConverter(typeof(DateTimeConverter))]
     public DateTime CreationTime { get; set; }
 
     public string HabboGroupId { get; set; }

--- a/Sulakore/Habbo/Web/HUser.cs
+++ b/Sulakore/Habbo/Web/HUser.cs
@@ -1,4 +1,8 @@
-﻿namespace Sulakore.Habbo.Web;
+﻿using Sulakore.Habbo.Web.Json;
+
+using System.Text.Json.Serialization;
+
+namespace Sulakore.Habbo.Web;
 
 [System.Diagnostics.DebuggerDisplay("Name: {Name}")]
 public class HUser
@@ -12,8 +16,13 @@ public class HUser
     public bool? BuildersClubMember { get; set; }
     public bool? HabboClubMember { get; set; }
 
+    [JsonConverter(typeof(DateTimeConverter.Nullable))]
     public DateTime? LastWebAccess { get; set; }
+    
+    [JsonConverter(typeof(DateTimeConverter.Nullable))]
     public DateTime? CreationTime { get; set; }
+
+    [JsonConverter(typeof(DateTimeConverter.Nullable))]
     public DateTime? MemberSince { get; set; }
 
     public long SessionLogId { get; set; }

--- a/Sulakore/Habbo/Web/Json/DateTimeConverter.cs
+++ b/Sulakore/Habbo/Web/Json/DateTimeConverter.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Sulakore.Habbo.Web.Json;
 
-public class DateTimeConverter : JsonConverter<DateTime>
+public sealed class DateTimeConverter : JsonConverter<DateTime>
 {
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         => DateTime.Parse(reader.GetString()!);
@@ -11,5 +11,20 @@ public class DateTimeConverter : JsonConverter<DateTime>
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
         writer.WriteStringValue(value.ToString("yyyy-MM-dd'T'HH:mm:ss.fff+0000"));
+    }
+
+    public sealed class Nullable : JsonConverter<DateTime?>
+    {
+        public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (DateTime.TryParse(reader.GetString(), out DateTime value))
+                return value;
+            return default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value?.ToString("yyyy-MM-dd'T'HH:mm:ss.fff+0000"));
+        }
     }
 }

--- a/Sulakore/Habbo/Web/Json/HJsonContext.cs
+++ b/Sulakore/Habbo/Web/Json/HJsonContext.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sulakore.Habbo.Web.Json;
+
+[JsonSerializable(typeof(HBadge))]
+[JsonSerializable(typeof(HFriend))]
+[JsonSerializable(typeof(HGroup))]
+[JsonSerializable(typeof(HProfile))]
+[JsonSerializable(typeof(HRoom))]
+[JsonSerializable(typeof(HUser))]
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public sealed partial class HJsonContext : JsonSerializerContext
+{ }

--- a/Sulakore/Sulakore.csproj
+++ b/Sulakore/Sulakore.csproj
@@ -14,12 +14,4 @@
 		<AdditionalFiles Include="messages.json" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <EditorConfigFiles Remove="C:\Users\null\Documents\Repositories\Sulakore-develop-namespaces\Sulakore\.editorconfig" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Include="C:\Users\null\Documents\Repositories\Sulakore-develop-namespaces\Sulakore\.editorconfig" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Renamed `HAPI.ReadContentAsync<T>` to `HAPI.GetAsync<T>`
- Added `CancellationToken`s to HAPI methods
- Added HJsonContext which stores the compile-time generated type metadata for JSON deserialization.
- Adjusted the DateTime converters a bit

Contributes to #38 