### PR TITLE
Refactor HPhoto

### DIFF
--- a/Sulakore.Tests/Habbo/HPhotoTests.cs
+++ b/Sulakore.Tests/Habbo/HPhotoTests.cs
@@ -1,0 +1,24 @@
+﻿using Sulakore.Habbo.Camera;
+
+using Xunit;
+
+namespace Sulakore.Tests.Habbo;
+
+public class HPhotoTests
+{
+    [Fact]
+    public void HPhoto_EmptySerializeDeserialize()
+    {
+        string emptyPhotoJson = new HPhoto().ToString();
+        var deserializedPhoto = HPhoto.Create(emptyPhotoJson);
+
+        Assert.NotNull(deserializedPhoto);
+        Assert.Empty(deserializedPhoto!.Planes);
+        Assert.Empty(deserializedPhoto!.Sprites);
+        Assert.Equal(deserializedPhoto!.Modifiers, new Modifiers());
+        Assert.Empty(deserializedPhoto!.Filters);
+
+        Assert.Equal((uint)0, deserializedPhoto.RoomId);
+        Assert.Null(deserializedPhoto.Zoom);
+    }
+}

--- a/Sulakore/Habbo/Camera/Filter.cs
+++ b/Sulakore/Habbo/Camera/Filter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Sulakore.Habbo.Camera;
 
-public class Filter
+public sealed record Filter
 {
     public int Alpha { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = default!;
 }

--- a/Sulakore/Habbo/Camera/HPhotoJsonContext.cs
+++ b/Sulakore/Habbo/Camera/HPhotoJsonContext.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sulakore.Habbo.Camera;
+
+[JsonSerializable(typeof(HPhoto))]
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public sealed partial class HPhotoJsonContext : JsonSerializerContext
+{ }

--- a/Sulakore/Habbo/Camera/Mask.cs
+++ b/Sulakore/Habbo/Camera/Mask.cs
@@ -1,12 +1,16 @@
 ﻿using System.Drawing;
+using System.Text.Json.Serialization;
 
-#nullable enable
 namespace Sulakore.Habbo.Camera;
 
-public class Mask
+public sealed record Mask
 {
     public string? Name { get; set; }
     public Point Location { get; set; }
-    public bool? FlipH { get; set; }
-    public bool? FlipV { get; set; }
+    
+    [JsonPropertyName("flipH")]
+    public bool? FlipHorizantally { get; set; }
+
+    [JsonPropertyName("flipV")]
+    public bool? FlipVertically { get; set; }
 }

--- a/Sulakore/Habbo/Camera/Modifiers.cs
+++ b/Sulakore/Habbo/Camera/Modifiers.cs
@@ -1,4 +1,4 @@
 ﻿namespace Sulakore.Habbo.Camera;
 
-public class Modifiers
+public sealed record Modifiers
 { }

--- a/Sulakore/Habbo/Camera/PhotoColorConverter.cs
+++ b/Sulakore/Habbo/Camera/PhotoColorConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Drawing;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sulakore.Habbo.Camera;
+
+internal sealed class PhotoColorConverter : JsonConverter<Color>
+{
+    public override Color Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => Color.FromArgb(reader.GetInt32());
+    public override void Write(Utf8JsonWriter writer, Color value, JsonSerializerOptions options) => writer.WriteNumberValue(value.ToArgb());
+
+    internal sealed class Nullable : JsonConverter<Color?>
+    {
+        public override Color? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => Color.FromArgb(reader.GetInt32());
+        public override void Write(Utf8JsonWriter writer, Color? value, JsonSerializerOptions options) => writer.WriteNumberValue(value.GetValueOrDefault().ToArgb());
+    }
+}

--- a/Sulakore/Habbo/Camera/Plane.cs
+++ b/Sulakore/Habbo/Camera/Plane.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 #nullable enable
 namespace Sulakore.Habbo.Camera;
 
-public class Plane
+public sealed record Plane
 {
     public IList<Point> CornerPoints { get; set; } = new List<Point>();
 
@@ -12,8 +12,12 @@ public class Plane
     public bool IsBottomAligned { get; set; }
 
     public IList<Mask>? Masks { get; set; }
-    public IList<TextureColumn> TexCols { get; set; } = new List<TextureColumn>();
+
+    [JsonPropertyName("texCols")]
+    public IList<TextureColumn> TextureColumns { get; set; } = new List<TextureColumn>();
 
     public double Z { get; set; }
-    public int Color { get; set; }
+
+    [JsonConverter(typeof(PhotoColorConverter))]
+    public Color Color { get; set; }
 }

--- a/Sulakore/Habbo/Camera/Sprite.cs
+++ b/Sulakore/Habbo/Camera/Sprite.cs
@@ -1,8 +1,12 @@
-﻿namespace Sulakore.Habbo.Camera;
+﻿using System.Drawing;
+using System.Text.Json.Serialization;
 
-public class Sprite
+namespace Sulakore.Habbo.Camera;
+
+public sealed record Sprite
 {
-    public bool? FlipH { get; set; }
+    [JsonPropertyName("flipH")]
+    public bool? FlipHorizantally { get; set; }
 
     public int X { get; set; }
     public int? Width { get; set; }
@@ -13,10 +17,10 @@ public class Sprite
     public bool? Frame { get; set; }
     public double? Skew { get; set; }
     public int? Alpha { get; set; }
-    public int? Color { get; set; }
-    public string BlendMode { get; set; }
-    
-    public string Name { get; set; }
 
-    public override string ToString() => Name;
+    [JsonConverter(typeof(PhotoColorConverter.Nullable))]
+    public Color? Color { get; set; }
+
+    public string BlendMode { get; set; } = default!;
+    public string Name { get; set; } = default!;
 }

--- a/Sulakore/Habbo/Camera/TextureColumn.cs
+++ b/Sulakore/Habbo/Camera/TextureColumn.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sulakore.Habbo.Camera;
 
-public class TextureColumn
+public sealed record TextureColumn
 {
     public List<string> AssetNames { get; set; } = new List<string>();
 }

--- a/Sulakore/Sulakore.csproj
+++ b/Sulakore/Sulakore.csproj
@@ -4,6 +4,10 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<LangVersion>preview</LangVersion>
+		
+		<IsTrimmable>true</IsTrimmable>
+		<TrimmerSingleWarn>false</TrimmerSingleWarn>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Refactored HPhoto to use AOT/trimming friendly JSON (de)serialization logic. Now Sulakore is marked `IsTrimmable`. 

We should add more tests for the HPhoto in the future. The serialization logic can also be optimized with pooled `IBufferWriter<byte>` implementation.

Fixes #38.