### PR TITLE
Add generic math interfaces to HPoint

### DIFF
--- a/Sulakore.Tests/Habbo/HPointTests.cs
+++ b/Sulakore.Tests/Habbo/HPointTests.cs
@@ -1,0 +1,69 @@
+﻿using Sulakore.Habbo;
+
+using Xunit;
+
+namespace Sulakore.Tests.Habbo;
+
+public class HPointTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("-")]
+    [InlineData(".")]
+    [InlineData(",")]
+    [InlineData(",,")]
+    [InlineData(",,,")]
+    [InlineData(",,,,")]
+    [InlineData("0,")]
+    [InlineData(",0")]
+    [InlineData("0.0")]
+    [InlineData("0,0,")]
+    [InlineData("0,,0")]
+    [InlineData("0,0,0,")]
+    public void HPoint_Parse_ShouldThrowFormatExceptionForInvalid(string input)
+    {
+        Assert.Throws<FormatException>(() => HPoint.Parse(input));
+    }
+
+    public static IEnumerable<object[]> TestData => new List<object[]>
+        {
+            new object[] { "0,0",         new HPoint(0, 0) },
+            new object[] { "4,2",         new HPoint(4, 2) },
+            new object[] { "4, 2",        new HPoint(4, 2) },
+            new object[] { "0,0,0",       new HPoint(0, 0) },
+            new object[] { "4,2,0",       new HPoint(4, 2) },
+            new object[] { " 4 , 2 , 0 ", new HPoint(4, 2) },
+            new object[] { "4 ,2 ,0 ",    new HPoint(4, 2) },
+            new object[] { " 4, 2, 0",    new HPoint(4, 2) },
+            new object[] { "4,2,0.0",     new HPoint(4, 2) },
+            
+            // Z Equals under default epsilon (0.01f)
+            new object[] { "0,0,0",     new HPoint(0, 0, 0f) },
+            new object[] { "0,0,0.0",   new HPoint(0, 0, 0f) },
+            new object[] { "0,0,-0",    new HPoint(0, 0, -0f) },
+            new object[] { "0,0,-0.0",  new HPoint(0, 0, -0f) },
+            new object[] { "1,2,3",     new HPoint(1, 2, 3f) },
+            new object[] { "1,2,3.0",   new HPoint(1, 2, 3f) },
+            new object[] { "1,2,3.005", new HPoint(1, 2, 3f) },
+            new object[] { "1,2,-3",    new HPoint(1, 2, -3f) },
+            new object[] { "1,2,-3.0",  new HPoint(1, 2, -3f) },
+        };
+
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public void HPoint_Parse_EqualsXY(string input, HPoint expected)
+    {
+        Assert.Equal(expected, HPoint.Parse(input));
+    }
+
+
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public void HPoint_Parse_EqualsXYZ(string input, HPoint expected)
+    {
+        Assert.True(HPoint.TryParse(input, out HPoint actual));
+        Assert.True(expected.Equals(actual, HPoint.DEFAULT_EPSILON));
+    }
+}

--- a/Sulakore/Habbo/HPoint.cs
+++ b/Sulakore/Habbo/HPoint.cs
@@ -1,30 +1,39 @@
 ﻿using System.Drawing;
 using System.Numerics;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 using Sulakore.Network.Formats;
 
 namespace Sulakore.Habbo;
 
 /// <summary>
-/// Represents an ordered pair of x-, y-, and z- coordinates that defines a point in a three-dimensional space.
+/// Represents a three-tuple of x-, y-, and z-coordinates that define a point in a three-dimensional space.
 /// </summary>
-public struct HPoint : IEquatable<HPoint>, IHFormattable, ISpanFormattable
+public struct HPoint : IEquatable<HPoint>,
+    ISpanFormattable, ISpanParsable<HPoint>,
+    IAdditiveIdentity<HPoint, HPoint>,
+    IAdditionOperators<HPoint, HPoint, HPoint>,
+    ISubtractionOperators<HPoint, HPoint, HPoint>,
+    IEqualityOperators<HPoint, HPoint, bool>
 {
     public const float DEFAULT_EPSILON = 0.01f;
 
     private static readonly HPoint _origin = new();
     public static ref readonly HPoint Origin => ref _origin;
 
+    static HPoint IAdditiveIdentity<HPoint, HPoint>.AdditiveIdentity => Origin;
+
     public int X { readonly get; set; }
     public int Y { readonly get; set; }
     public float Z { readonly get; set; }
 
     public HPoint()
-        : this(0, 0, 0)
+        : this(0, 0, 0f)
     { }
     public HPoint(int x, int y)
-        : this(x, y, 0)
+        : this(x, y, 0f)
     { }
     public HPoint(int x, int y, char level)
         : this(x, y, ToZ(level))
@@ -32,22 +41,23 @@ public struct HPoint : IEquatable<HPoint>, IHFormattable, ISpanFormattable
     public HPoint(int x, int y, float z)
         => (X, Y, Z) = (x, y, z);
 
+    public readonly void Deconstruct(out int x, out int y) => (x, y) = (X, Y);
+    public readonly void Deconstruct(out int x, out int y, out float z) => (x, y, z) = (X, Y, Z);
+
     public override readonly string ToString()
-        => ToString(format: null);
+        => string.Create(CultureInfo.InvariantCulture, stackalloc char[64], $"{X}, {Y}, {Z}");
 
     public override readonly int GetHashCode() => HashCode.Combine(X, Y, Z);
-    public override readonly bool Equals(object? obj)
+    public override readonly bool Equals(object? obj) => obj switch
     {
-        if (obj is HPoint other)
-            return Equals(other);
-        else if (obj is ValueTuple<int, int> t2)
-            return Equals(t2);
-        else if (obj is ValueTuple<int, int, float> t3)
-            return Equals(t3);
-        else return false;
-    }
+        HPoint other => Equals(other),
+        ValueTuple<int, int> xy => Equals(xy),
+        ValueTuple<int, int, float> xyx => Equals(xyx),
+        _ => false
+    };
 
-    public readonly bool Equals(HPoint other) => Equals(other);
+    public readonly bool Equals(HPoint other)
+        => X == other.X && Y == other.Y;
     public readonly bool Equals(HPoint other, float epsilon = DEFAULT_EPSILON)
         => X == other.X && Y == other.Y && Math.Abs(other.Z - Z) < epsilon;
 
@@ -57,11 +67,6 @@ public struct HPoint : IEquatable<HPoint>, IHFormattable, ISpanFormattable
         => X == point.X && Y == point.Y && Math.Abs(point.Z - Z) < epsilon;
     public readonly bool Equals((int X, int Y, float Z) point, float epsilon = DEFAULT_EPSILON)
         => X == point.X && Y == point.Y && Math.Abs(point.Z - Z) < epsilon;
-
-    public readonly bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = default)
-        => destination.TryWrite(CultureInfo.InvariantCulture, $"{X}, {Y}, {Z}", out charsWritten);
-    public readonly string ToString(string? format, IFormatProvider? formatProvider = default)
-        => string.Create(CultureInfo.InvariantCulture, stackalloc char[64], $"{X}, {Y}, {Z}");
 
     public readonly bool TryFormat(Span<byte> destination, IHFormat format, out int bytesWritten, ReadOnlySpan<char> formatString)
         => destination.TryWrite(format, $"{X}{Y}", out bytesWritten);
@@ -75,38 +80,93 @@ public struct HPoint : IEquatable<HPoint>, IHFormattable, ISpanFormattable
     public static implicit operator Vector2(HPoint point) => new(point.X, point.Y);
     public static implicit operator Vector3(HPoint point) => new(point.X, point.Y, point.Z);
 
-    public static implicit operator (int X, int Y)(HPoint point) => (point.X, point.Y);
-    public static implicit operator (int X, int Y, float Z)(HPoint point) => (point.X, point.Y, point.Z);
-
     public static implicit operator HPoint((int X, int Y) point) => new(point.X, point.Y);
     public static implicit operator HPoint((int X, int Y, float Z) point) => new(point.X, point.Y, point.Z);
 
     public static HPoint operator +(HPoint point, (int X, int Y) offset) => new(point.X + offset.X, point.Y + offset.Y);
-    public static HPoint operator +(HPoint point, (int X, int Y, int Z) offset) => new(point.X + offset.X, point.Y + offset.Y, point.Z + offset.Z);
     public static HPoint operator +(HPoint point, (int X, int Y, float Z) offset) => new(point.X + offset.X, point.Y + offset.Y, point.Z + offset.Z);
-    public static HPoint operator +(HPoint left, HPoint right) => new(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
 
     public static HPoint operator -(HPoint point, (int X, int Y) offset) => new(point.X - offset.X, point.Y - offset.Y);
-    public static HPoint operator -(HPoint point, (int X, int Y, int Z) offset) => new(point.X - offset.X, point.Y - offset.Y, point.Z - offset.Z);
     public static HPoint operator -(HPoint point, (int X, int Y, float Z) offset) => new(point.X - offset.X, point.Y - offset.Y, point.Z - offset.Z);
+
+    public static HPoint operator +(HPoint left, HPoint right) => new(left.X + right.X, left.Y + right.Y, left.Z + right.Z);
     public static HPoint operator -(HPoint left, HPoint right) => new(left.X - right.X, left.Y - right.Y, left.Z - right.Z);
 
-    public static char ToLevel(float z)
+    public static char ToLevel(float z) => z switch
     {
-        return z switch
-        {
-            >= 0 and <= 9 => (char)(z + 48),
-            >= 10 and <= 29 => (char)(z + 87),
-            _ => 'x'
-        };
-    }
-    public static float ToZ(char level)
+        >= 0 and <= 9 => (char)(z + 48),
+        >= 10 and <= 29 => (char)(z + 87),
+        _ => 'x'
+    };
+    public static float ToZ(char level) => level switch
     {
-        return level switch
-        {
-            >= '0' and <= '9' => level - 48,
-            >= 'a' and <= 't' => level - 87,
-            _ => 0
-        };
+        >= '0' and <= '9' => level - 48,
+        >= 'a' and <= 't' => level - 87,
+        _ => 0
+    };
+
+    /// <summary>
+    /// Parses a comma-separated two- or three-tuple as <see cref="HPoint"/> value.
+    /// </summary>
+    public static HPoint Parse(ReadOnlySpan<char> s, IFormatProvider? provider = null)
+    {
+        if (!TryParse(s, out HPoint result))
+            ThrowHelper.ThrowFormatException();
+        return result;
     }
+    /// <inheritdoc cref="Parse(ReadOnlySpan{char}, IFormatProvider?)"/>
+    public static HPoint Parse(string s, IFormatProvider? provider = null) => Parse(s.AsSpan());
+
+    /// <inheritdoc cref="Parse(ReadOnlySpan{char}, IFormatProvider?)"/>
+    public static bool TryParse(ReadOnlySpan<char> s, out HPoint result)
+    {
+        Unsafe.SkipInit(out result);
+
+        // Try parse an integer before first comma.
+        int separatorIndex = s.IndexOf(',');
+        if (separatorIndex <= 0 ||
+            !int.TryParse(s.Slice(0, separatorIndex), NumberStyles.Integer, CultureInfo.InvariantCulture, out int x))
+        {
+            return false;
+        }
+
+        // Slice out the parsed X-coordinate and the first comma.
+        s = s.Slice(separatorIndex + 1);
+
+        // After the first comma, parse the Y-coordinate as an integer.
+        // If there's still one more comma in the input,
+        // try to parse the Z-coordinate as a floating-point number.
+
+        int y;
+        float z;
+
+        separatorIndex = s.IndexOf(',');        
+        if (separatorIndex == -1)
+        {
+            if (int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out y))
+            {
+                result = new HPoint(x, y);
+                return true;
+            }
+        }
+        else if (int.TryParse(s.Slice(0, separatorIndex), NumberStyles.Integer, CultureInfo.InvariantCulture, out y) &&
+            float.TryParse(s.Slice(separatorIndex + 1), NumberStyles.Float, CultureInfo.InvariantCulture, out z))
+        {
+            result = new HPoint(x, y, z);
+            return true;
+        }
+
+        return false;
+    }
+    /// <inheritdoc cref="Parse(ReadOnlySpan{char}, IFormatProvider?)"/>
+    public static bool TryParse([NotNullWhen(true)] string? s, out HPoint result) => TryParse(s.AsSpan(), out result);
+
+    readonly bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        => destination.TryWrite(CultureInfo.InvariantCulture, $"{X}, {Y}, {Z}", out charsWritten);
+    readonly string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
+
+    /// <inheritdoc cref="Parse(ReadOnlySpan{char}, IFormatProvider?)"/>
+    static bool ISpanParsable<HPoint>.TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out HPoint result) => TryParse(s, out result);
+    /// <inheritdoc cref="Parse(ReadOnlySpan{char}, IFormatProvider?)"/>
+    static bool IParsable<HPoint>.TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out HPoint result) => TryParse(s.AsSpan(), out result);
 }

--- a/Sulakore/Internals/ThrowHelper.cs
+++ b/Sulakore/Internals/ThrowHelper.cs
@@ -25,4 +25,8 @@ internal static class ThrowHelper
 
     [DoesNotReturn]
     internal static void ThrowNullReferenceException(string? message = null) => throw new NullReferenceException(message);
+
+    [DoesNotReturn]
+    internal static void ThrowFormatException(string? message = null) => throw new FormatException(message);
+
 }


### PR DESCRIPTION
Added some generic math interface to `HPoint` and refactored its public API implementation (tuple destructuring and some of the operators). Includes basic test coverage for the new parsing `ISpanParsable<HPoint>` implementation